### PR TITLE
Allow detecting a '0' duration heartbeat as a success

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"sync"
 
-	"golang.ngrok.com/muxado/frame"
+	"golang.ngrok.com/muxado/v2/frame"
 )
 
 var zeroConfig Config

--- a/errors.go
+++ b/errors.go
@@ -3,7 +3,7 @@ package muxado
 import (
 	"errors"
 
-	"golang.ngrok.com/muxado/frame"
+	"golang.ngrok.com/muxado/v2/frame"
 )
 
 // ErrorCode is a 32-bit integer indicating the type of an error condition

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module golang.ngrok.com/muxado
+module golang.ngrok.com/muxado/v2
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module golang.ngrok.com/muxado
 go 1.20
 
 require (
-	github.com/hashicorp/yamux v0.1.1 // indirect
-	golang.org/x/crypto v0.9.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
+	github.com/hashicorp/yamux v0.1.1
+	golang.org/x/crypto v0.9.0
 )
+
+require golang.org/x/sys v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,4 @@ golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
 golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.8.0 h1:n5xxQn2i3PC0yLAbjTpNT85q/Kgzcr2gIoX9OrJUols=

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -1,0 +1,61 @@
+package muxado
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestHeartbeatFast is a regression test for a 0ms
+// timeout being detectable
+func TestHeartbeatFast(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, serv := net.Pipe()
+	stopServerHBs := make(chan struct{})
+	go func() {
+		sess := Server(serv, nil)
+		typed := NewTypedStreamSession(sess)
+		hb := NewHeartbeat(typed, func(d time.Duration, timeout bool) {
+			if timeout {
+				panic("timeout")
+			}
+		}, &HeartbeatConfig{
+			Interval:  5 * time.Millisecond,
+			Tolerance: 100 * time.Millisecond,
+			Type:      defaultStreamType,
+		})
+		str, err := hb.AcceptTypedStream()
+		if err != nil {
+			panic(err)
+		}
+		<-stopServerHBs
+		str.Close()
+
+		<-ctx.Done()
+		sess.Close()
+	}()
+
+	clientSess := Client(client, nil)
+	clientTyped := NewTypedStreamSession(clientSess)
+	hb := NewHeartbeat(clientTyped, func(d time.Duration, timeout bool) {
+		if timeout {
+			panic("timeout")
+		}
+	}, &HeartbeatConfig{
+		Interval:  5 * time.Millisecond,
+		Tolerance: 500 * time.Millisecond,
+		Type:      defaultStreamType,
+	})
+	hb.Start()
+
+	for i := 0; i < 10; i++ {
+		_, ok := hb.Beat()
+		if !ok {
+			t.Fatal("beat failed")
+		}
+	}
+
+}

--- a/session.go
+++ b/session.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.ngrok.com/muxado/frame"
+	"golang.ngrok.com/muxado/v2/frame"
 )
 
 // private interface for Sessions to call Streams

--- a/session_test.go
+++ b/session_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.ngrok.com/muxado/frame"
+	"golang.ngrok.com/muxado/v2/frame"
 )
 
 func newFakeStream(sess sessionPrivate, id frame.StreamId, windowSize uint32, fin bool, init bool) streamPrivate {

--- a/stream.go
+++ b/stream.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.ngrok.com/muxado/frame"
+	"golang.ngrok.com/muxado/v2/frame"
 )
 
 var (

--- a/stream_map.go
+++ b/stream_map.go
@@ -3,7 +3,7 @@ package muxado
 import (
 	"sync"
 
-	"golang.ngrok.com/muxado/frame"
+	"golang.ngrok.com/muxado/v2/frame"
 )
 
 const (

--- a/stream_test.go
+++ b/stream_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"golang.ngrok.com/muxado/frame"
+	"golang.ngrok.com/muxado/v2/frame"
 )
 
 func TestCloseWrite(t *testing.T) {


### PR DESCRIPTION
Before, 0 was overloaded to mean both failure _and_ a near-instant heartbeat.

Add a bool to get the additional 'failure' meaning.

I don't have any sorta repro for actually seeing a 0 there, but I've seen some logs indicating this might be possible, and it seems like a correctness improvement to me at least.

Leaving this in draft for the second since this is **backwards incompatible**, so probably means a v2 bump :/