### PR TITLE
Reset the heartbeat ticker to ensure the interval is up-to-date

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
           gotools
           go-tools
           golangci-lint
+          gopls
         ];
       };
     }));

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -182,6 +182,9 @@ func (h *Heartbeat) requester(mark chan time.Duration) {
 		select {
 		case respChan = <-h.onDemand:
 		case <-ticker.C:
+			// Make sure we're always using an up-to-date heartbeat interval
+			interval, _ := h.getDurations()
+			ticker.Reset(interval)
 		}
 
 		start := time.Now()


### PR DESCRIPTION
Resolves ngrok-private/ngrok#33429

The intent was always to honor the heartbeat interval/duration set in the ngrok agent configuration, and indeed we were calling the `Heartbeat.SetInterval` and `Heartbeat.SetTolerance` methods. Unfortunately, while `Heartbeat.check` reloaded these durations after each heartbeat to ensure that they're up-to-date, `Heatbeat.requester` did not.

This makes it so that after each "tick," the ticker is reset to the latest interval.