### PR TITLE
flake: update go version (1.20 -> 1.24)

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -10,8 +10,8 @@ import (
 )
 
 var (
-	bufferFull   = errors.New("buffer is full")
-	bufferClosed = errors.New("buffer closed previously")
+	errBufferFull   = errors.New("buffer is full")
+	errBufferClosed = errors.New("buffer closed previously")
 )
 
 type buffer interface {
@@ -41,16 +41,16 @@ func (b *inboundBuffer) ReadFrom(rd io.Reader) (n int64, err error) {
 	b.mu.Lock()
 	if b.err != nil {
 		if _, err = io.ReadAll(rd); err == nil {
-			err = bufferClosed
+			err = errBufferClosed
 		}
 		goto DONE
 	}
 
 	n64, err = b.Buffer.ReadFrom(rd)
 	n += n64
-	if b.Buffer.Len() > b.maxSize {
-		err = bufferFull
-		b.err = bufferFull
+	if b.Len() > b.maxSize {
+		err = errBufferFull
+		b.err = errBufferFull
 	}
 
 	b.cond.Broadcast()

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735617354,
-        "narHash": "sha256-5zJyv66q68QZJZsXtmjDBazGnF0id593VSy+8eSckoo=",
+        "lastModified": 1743320628,
+        "narHash": "sha256-FurMxmjEEqEMld11eX2vgfAx0Rz0JhoFm8UgxbfCZa8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "69b9a8c860bdbb977adfa9c5e817ccb717884182",
+        "rev": "63158b9cbb6ec93d26255871c447b0f01da81619",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686277352,
-        "narHash": "sha256-quryYLnntwZZrwJ4Vsx24hiCkwiYZAEttiOu983akGg=",
+        "lastModified": 1735617354,
+        "narHash": "sha256-5zJyv66q68QZJZsXtmjDBazGnF0id593VSy+8eSckoo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a9fa8f8450a2ae296f152a9b3d52df68d24b7cfc",
+        "rev": "69b9a8c860bdbb977adfa9c5e817ccb717884182",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     {
       devShells.default = pkgs.mkShell {
         buildInputs = with pkgs; [
-          go_1_23
+          go_1_24
           gotools
           go-tools
           golangci-lint

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     {
       devShells.default = pkgs.mkShell {
         buildInputs = with pkgs; [
-          go_1_20
+          go_1_23
           gotools
           go-tools
           golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golang.ngrok.com/muxado/v2
 
-go 1.20
+go 1.21
 
 require (
 	github.com/hashicorp/yamux v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -5,3 +5,4 @@ golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.8.0 h1:n5xxQn2i3PC0yLAbjTpNT85q/Kgzcr2gIoX9OrJUols=
+golang.org/x/term v0.8.0/go.mod h1:xPskH00ivmX89bAKVGSKKtLOWNx2+17Eiy94tnKShWo=

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -170,7 +170,9 @@ func (h *Heartbeat) requester(mark chan time.Duration) {
 	if err != nil {
 		return
 	}
-	defer stream.Close()
+	defer func() {
+		_ = stream.Close()
+	}()
 
 	interval, _ := h.getDurations()
 	ticker := time.NewTicker(interval)

--- a/session.go
+++ b/session.go
@@ -208,6 +208,8 @@ func (s *session) Addr() net.Addr {
 	return s.LocalAddr()
 }
 
+// nolint:staticcheck // For backwards compatibility, don't fix the 'error
+// last' lint until we're ready for a major version bump.
 func (s *session) Wait() (error, error, []byte) {
 	<-s.dead
 	dbg := s.remoteDebug.Load().(remoteDebug)
@@ -254,7 +256,7 @@ func (s *session) writeFrame(f frame.Frame, dl time.Time) error {
 	if !dl.IsZero() {
 		timeout = time.After(time.Until(dl))
 	}
-	var req = writeReq{f: f, err: poolGet().(chan error)}
+	req := writeReq{f: f, err: poolGet().(chan error)}
 	select {
 	case s.writeFrames <- req:
 	case <-s.dead:
@@ -276,7 +278,7 @@ func (s *session) writeFrame(f frame.Frame, dl time.Time) error {
 // like writeFrame but it returns immediately, do not use with any frame/buffer that will be reused
 // or free'd
 func (s *session) writeFrameAsync(f frame.Frame) error {
-	var req = writeReq{f: f}
+	req := writeReq{f: f}
 	select {
 	case s.writeFrames <- req:
 		return nil
@@ -306,7 +308,7 @@ func (s *session) die(err error) error {
 	close(s.dead)
 
 	// close the transport
-	s.transport.Close()
+	_ = s.transport.Close()
 
 	// notify all of the streams that we're closing
 	s.streams.Each(func(id frame.StreamId, str streamPrivate) {

--- a/typed_stream.go
+++ b/typed_stream.go
@@ -44,14 +44,14 @@ func (s *typedStreamSession) AcceptTypedStream() (TypedStream, error) {
 	var stype [4]byte
 	_, err = str.Read(stype[:])
 	if err != nil {
-		str.Close()
+		_ = str.Close()
 		return nil, err
 	}
 	return &typedStream{str, StreamType(order.Uint32(stype[:]))}, nil
 }
 
 func (s *typedStreamSession) OpenTypedStream(st StreamType) (Stream, error) {
-	str, err := s.Session.OpenStream()
+	str, err := s.OpenStream()
 	if err != nil {
 		return nil, err
 	}

--- a/window_manager.go
+++ b/window_manager.go
@@ -21,7 +21,7 @@ type condWindow struct {
 func (w *condWindow) Init(initialSize int) {
 	w.val = initialSize
 	w.maxSize = initialSize
-	w.Cond.L = &w.Mutex
+	w.L = &w.Mutex
 }
 
 func (w *condWindow) Increment(inc int) {


### PR DESCRIPTION
Just some rote maintenance. I've left the go.mod at `1.21` since [ngrok-go](https://github.com/ngrok/ngrok-go/blob/f7c015fa0e5f84cf20d8b2ed39dd9e1a42d5c7c8/go.mod) is also still at 1.21 right now.

I've also fixed newly added golang-ci lints, since otherwise CI complains.