### PR TITLE
Avoid racing between session close + adding new streams

### DIFF
--- a/deadlock_test.go
+++ b/deadlock_test.go
@@ -1,0 +1,86 @@
+package muxado
+
+import (
+	"testing"
+	"time"
+
+	"golang.ngrok.com/muxado/v2/frame"
+)
+
+// TestDieRaceMissesOrphanedStream is a regression test for a race condition in
+// session.die() where a stream created concurrently with session shutdown is
+// never cleaned up.
+//
+// The race:
+//  1. Reader goroutine enters handleSyn, calls newStream (custom factory blocks)
+//  2. Another goroutine calls sess.Close() -> die() -> streams.Each snapshots
+//     an empty map
+//  3. Factory unblocks, handleSyn calls streams.Set (stream now in map but
+//     missed by die's snapshot)
+//  4. The stream's buffer never gets an error set, so any Read blocks forever
+func TestDieRaceMissesOrphanedStream(t *testing.T) {
+	t.Parallel()
+
+	local, remote := newFakeConnPair()
+	remote.Discard()
+
+	factoryCalled := make(chan struct{})
+	factoryProceed := make(chan struct{})
+
+	var createdStream streamPrivate
+
+	customFactory := func(sess sessionPrivate, id frame.StreamId, windowSize uint32, fin bool, init bool) streamPrivate {
+		str := newStream(sess, id, windowSize, fin, init)
+		createdStream = str
+		close(factoryCalled)
+		<-factoryProceed
+		return str
+	}
+
+	sess := Server(local, &Config{newStream: customFactory})
+
+	// Send a zero-length SYN. WriteFrame is launched in a goroutine because
+	// the zero-length body write blocks on the pipe until the reader side
+	// returns from ReadFrame — but the reader is about to block in our
+	// factory. The goroutine unblocks when the transport is closed by die().
+	f := new(frame.Data)
+	f.Pack(1, []byte{}, false, true)
+	fr := frame.NewFramer(remote, remote)
+	go fr.WriteFrame(f)
+
+	// Wait for the factory to be called. At this point the reader goroutine
+	// is inside handleSyn, between newStream and streams.Set.
+	<-factoryCalled
+
+	// Close the session while the factory is blocked.
+	// die() snapshots an EMPTY stream map because Set() hasn't been called yet.
+	sess.Close()
+
+	// Unblock the factory. handleSyn continues:
+	//   streams.Set (adds to map — but die() already snapshotted)
+	//   accept <- str (channel has room, reader hasn't returned yet)
+	//   handleStreamData (no-op for zero-length frame)
+	// Then the reader checks s.dead, sees it closed, and returns.
+	close(factoryProceed)
+
+	// Give handleSyn time to finish.
+	time.Sleep(200 * time.Millisecond)
+
+	// The stream was NOT cleaned up by die() because it was added after
+	// the snapshot. Verify by reading — it should block forever because
+	// neither data nor error was ever set on the buffer.
+	readDone := make(chan error, 1)
+	go func() {
+		readBuf := make([]byte, 1)
+		_, err := createdStream.Read(readBuf)
+		readDone <- err
+	}()
+
+	select {
+	case <-time.After(500 * time.Millisecond):
+		// Expected: Read blocks because the stream was orphaned by die().
+		panic("test test failed, read never finished")
+	case <-readDone:
+		t.Log("read finsihed, success")
+	}
+}

--- a/session.go
+++ b/session.go
@@ -128,7 +128,11 @@ func (s *session) OpenStream() (Stream, error) {
 
 	// make the stream and add it to the stream map
 	str := s.config.newStream(s, nextId, s.config.MaxWindowSize, false, true)
-	s.streams.Set(nextId, str)
+	if !s.streams.Set(nextId, str) {
+		// race with die, abandon this stream
+		str.closeWith(sessionClosed)
+		return nil, remoteGoneAway
+	}
 
 	return str, nil
 }
@@ -311,9 +315,9 @@ func (s *session) die(err error) error {
 	_ = s.transport.Close()
 
 	// notify all of the streams that we're closing
-	s.streams.Each(func(id frame.StreamId, str streamPrivate) {
+	for _, str := range s.streams.Drain() {
 		str.closeWith(sessionClosed)
-	})
+	}
 
 	return nil
 }
@@ -499,7 +503,11 @@ func (s *session) handleSyn(f *frame.Data) (err error) {
 	str := s.config.newStream(s, f.StreamId(), s.config.MaxWindowSize, f.Fin(), false)
 
 	// add it to the stream map
-	s.streams.Set(f.StreamId(), str)
+	if !s.streams.Set(f.StreamId(), str) {
+		// race with die, abandon this stream
+		str.closeWith(sessionClosed)
+		return closeError
+	}
 
 	// put the new stream on the accept channel
 	var retry bool

--- a/stream_map.go
+++ b/stream_map.go
@@ -1,6 +1,7 @@
 package muxado
 
 import (
+	"maps"
 	"sync"
 
 	"golang.ngrok.com/muxado/v2/frame"
@@ -16,36 +17,59 @@ type streamMap struct {
 	table map[frame.StreamId]streamPrivate
 }
 
-func (m *streamMap) Get(id frame.StreamId) (s streamPrivate, ok bool) {
+func (m *streamMap) Get(id frame.StreamId) (streamPrivate, bool) {
 	m.RLock()
-	s, ok = m.table[id]
-	m.RUnlock()
-	return
+	defer m.RUnlock()
+	if m.table != nil {
+		s, ok := m.table[id]
+		return s, ok
+	}
+	return nil, false
 }
 
-func (m *streamMap) Set(id frame.StreamId, str streamPrivate) {
+// Set adds a stream to the map. It returns false if the stream could not be
+// added due to the streamMap having been drained already.
+func (m *streamMap) Set(id frame.StreamId, str streamPrivate) bool {
 	m.Lock()
+	defer m.Unlock()
+	if m.table == nil {
+		// already drained, let our caller know to give up
+		return false
+	}
 	m.table[id] = str
-	m.Unlock()
+	return true
 }
 
 func (m *streamMap) Delete(id frame.StreamId) {
 	m.Lock()
-	delete(m.table, id)
-	m.Unlock()
+	defer m.Unlock()
+	if m.table != nil {
+		delete(m.table, id)
+	}
 }
 
 func (m *streamMap) Each(fn func(frame.StreamId, streamPrivate)) {
 	m.RLock()
-	streams := make(map[frame.StreamId]streamPrivate, len(m.table))
-	for k, v := range m.table {
-		streams[k] = v
-	}
+	streams := maps.Clone(m.table)
 	m.RUnlock()
+	if streams == nil {
+		// already drained, do nothing
+		return
+	}
 
 	for id, str := range streams {
 		fn(id, str)
 	}
+}
+
+// Drain nils out the table under the write lock and returns all streams that
+// were in the map. After Drain, Set will return false for any new streams.
+func (m *streamMap) Drain() map[frame.StreamId]streamPrivate {
+	m.Lock()
+	defer m.Unlock()
+	streams := m.table
+	m.table = nil
+	return streams
 }
 
 func newStreamMap() *streamMap {


### PR DESCRIPTION
Until now, there was a subtle race between session.die and a new stream being created.

In session.die, we used `streamMap.Each` to close all streams. We also set `local.goneAway` in die, which in theory should mean new streams aren't added.

However, setting `goneAway`, iterating with `Each`, and adding a stream aren't adequately synchronized, so it's possible to end up in a state where we've got a goroutine already in `handleSyn`, about to add a new stream, and then we context switch to 'die' and cleanup existing streams, and then switch back and add the stream.

This puts the stream in a state where it will never get closed since `die` won't run again (due to `dieOnce`), however we won't process the stream properly since `die` closed the `s.dead` channel and cleaned up stuff related to that.

So, what's the fix?

Instead of using `streamMap.Each` during `die`, we use `streamMap.Drain()` to atomically clear the map and mark it drained, and then in Set we return whether we just added to a drained map (the race condition), and if we did we knock over the stream we just created.

The included test failed before this change.

The test was written by claude, the fix was written by me.